### PR TITLE
feat: Ruby plugin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+FEAT: Official support for running with prettier/plugin-ruby
+
 ## v0.1 (2021-03-31)
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - uses: planningcenter/balto-prettier@v0.1
+      - uses: planningcenter/balto-prettier@v0.2
         with:
           extensions: js,jsx
       - uses: stefanzweifel/git-auto-commit-action@v4
@@ -28,7 +28,11 @@ jobs:
           commit_message: Formatting by balto-prettier
 ```
 
-If you're using prettier plugins that rely on other tools or languages, you'll need to set those up, as well. For example, using the Ruby plugin to do the same sort of formatting commit as above might look like this:
+### prettier/plugin-ruby
+
+While you can use the [prettier plugin for Ruby](https://github.com/prettier/plugin-ruby) from node, for newer versions of the plugin (>= 3.0), you'll also need a few Ruby gems installed. The easiest way to make sure those dependencies are in place is for your project to include the [prettier gem](https://rubygems.org/gems/prettier) and keep that version synced with the version of the node package.
+
+If your project uses this plugin and it's part of your package.json, this action will automatically detect it and install the prettier gem from your Gemfile.lock. It's also setup so that you don't need to install all of your project's dependencies (note the `bundle: none` in the example below), making it quick.
 
 ```yaml
 name: Balto
@@ -45,8 +49,8 @@ jobs:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
-      - uses: planningcenter/balto-prettier@v0.1
+          bundler: none
+      - uses: planningcenter/balto-prettier@v0.2
         with:
           extensions: js,jsx,rb,rake
       - uses: stefanzweifel/git-auto-commit-action@v4
@@ -54,6 +58,9 @@ jobs:
           commit_message: Formatting by balto-prettier
 ```
 
+### Other Plugins
+
+If you're using other prettier plugins that rely on other tools or languages, you'll need to set those up, with other actions or steps.
 
 ## Inputs
 

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 const io = require('@actions/io')
 const core = require('@actions/core')
 const { easyExec } = require('./utils')
+const rubyPlugin = require('./ruby')
 
 const {
   GITHUB_WORKSPACE,
@@ -58,6 +59,7 @@ async function installPrettierPackages () {
   if (peerVersions.length > 0) {
     await easyExec(['npm i', ...peerVersions, '--no-package-lock'].join(' '))
   }
+  return versions
 }
 
 async function runPrettier () {
@@ -77,11 +79,17 @@ async function runPrettier () {
 }
 
 async function setup() {
-  await installPrettierPackages()
+  const packages = await installPrettierPackages()
+
+  const rubyPluginVersion = packages.find(p => p.match(/prettier\/plugin-ruby/))
+  if (rubyPluginVersion) {
+    await rubyPlugin.setup()
+  }
 }
 
 async function teardown() {
   await io.mv('package.json-bak', 'package.json')
+  await rubyPlugin.teardown()
 }
 
 async function run () {

--- a/main.js
+++ b/main.js
@@ -77,7 +77,9 @@ async function runPrettier () {
   const paths = output
     .split('\n')
     .filter(path => extensions.some(e => path.endsWith(`.${e}`)))
-  await easyExec(`${executable} --write ${paths.join(' ')}`)
+  if (paths.length > 0) {
+    await easyExec(`${executable} --write ${paths.join(' ')}`)
+  }
 }
 
 async function setup() {

--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ async function getPeerDependencies (error) {
   return versions
 }
 
-async function installPrettierPackagesAsync () {
+async function installPrettierPackages () {
   const yarn = await getYarn()
 
   const versions = yarn.data.trees
@@ -83,7 +83,7 @@ async function runPrettier () {
 async function run () {
   try {
     process.chdir(GITHUB_WORKSPACE)
-    await installPrettierPackagesAsync()
+    await installPrettierPackages()
     report = await runPrettier()
   } catch (e) {
     core.setFailed(e.message)

--- a/main.js
+++ b/main.js
@@ -85,6 +85,7 @@ async function setup() {
 
   availablePlugins.forEach((p) => {
     if (packages.find(pa => pa.match(p.packageMatcher))) {
+      console.log(`Enabling plugin: ${p.name}`)
       enabledPlugins.push(p)
     }
   })

--- a/main.js
+++ b/main.js
@@ -81,7 +81,7 @@ async function runPrettier () {
 async function setup() {
   const packages = await installPrettierPackages()
 
-  const rubyPluginVersion = packages.find(p => p.match(/prettier\/plugin-ruby/))
+  const rubyPluginVersion = packages.find(p => p.match(rubyPlugin.packageMatcher))
   if (rubyPluginVersion) {
     await rubyPlugin.setup()
   }

--- a/main.js
+++ b/main.js
@@ -51,16 +51,12 @@ async function installPrettierPackages () {
 
   await io.mv('package.json', 'package.json-bak')
 
-  try {
-    const { error } = await easyExec(
-      ['npm i', ...versions, '--no-package-lock'].join(' ')
-    )
-    const peerVersions = await getPeerDependencies(error)
-    if (peerVersions.length > 0) {
-      await easyExec(['npm i', ...peerVersions, '--no-package-lock'].join(' '))
-    }
-  } finally {
-    await io.mv('package.json-bak', 'package.json')
+  const { error } = await easyExec(
+    ['npm i', ...versions, '--no-package-lock'].join(' ')
+  )
+  const peerVersions = await getPeerDependencies(error)
+  if (peerVersions.length > 0) {
+    await easyExec(['npm i', ...peerVersions, '--no-package-lock'].join(' '))
   }
 }
 
@@ -84,6 +80,10 @@ async function setup() {
   await installPrettierPackages()
 }
 
+async function teardown() {
+  await io.mv('package.json-bak', 'package.json')
+}
+
 async function run () {
   try {
     process.chdir(GITHUB_WORKSPACE)
@@ -91,6 +91,8 @@ async function run () {
     report = await runPrettier()
   } catch (e) {
     core.setFailed(e.message)
+  } finally {
+    await teardown()
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -80,10 +80,14 @@ async function runPrettier () {
   await easyExec(`${executable} --write ${paths.join(' ')}`)
 }
 
+async function setup() {
+  await installPrettierPackages()
+}
+
 async function run () {
   try {
     process.chdir(GITHUB_WORKSPACE)
-    await installPrettierPackages()
+    await setup()
     report = await runPrettier()
   } catch (e) {
     core.setFailed(e.message)

--- a/ruby.js
+++ b/ruby.js
@@ -1,0 +1,39 @@
+const io = require("@actions/io")
+const { readFile } = require("fs")
+const { promisify } = require("util")
+const { easyExec } = require('./utils')
+
+const readFileAsync = promisify(readFile)
+
+let gemVersion = null
+
+async function getGemVersion() {
+  if (gemVersion) return gemVersion
+
+  await readFileAsync("Gemfile.lock").then((data) => {
+    const match = data.toString().match(/prettier \((?<version>[\d.]+)\)/)
+    if (match) {
+      gemVersion = match.groups.version
+    } else {
+      console.log("No prettier gem found in Gemfile.lock. Skipping..." )
+    }
+  }).catch((error) => {
+    console.error(error)
+  })
+
+  return gemVersion
+}
+
+exports.setup = async function setup() {
+  const version = await getGemVersion()
+
+  await io.mv("Gemfile", "Gemfile.bak")
+
+  if (version) {
+    await easyExec(["gem install prettier -v", version].join(" "))
+  }
+}
+
+exports.teardown = async function teardown() {
+  await io.mv("Gemfile.bak", "Gemfile")
+}

--- a/ruby.js
+++ b/ruby.js
@@ -37,3 +37,5 @@ exports.setup = async function setup() {
 exports.teardown = async function teardown() {
   await io.mv("Gemfile.bak", "Gemfile")
 }
+
+exports.packageMatcher = /prettier\/plugin-ruby/

--- a/ruby.js
+++ b/ruby.js
@@ -39,3 +39,4 @@ exports.teardown = async function teardown() {
 }
 
 exports.packageMatcher = /prettier\/plugin-ruby/
+exports.name = "Ruby"

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,8 @@ exports.easyExec = async function easyExec (commandWithArgs) {
   let output = ''
   let error = ''
 
+  const debugMode = `${process.env.ACTIONS_STEP_DEBUG}`.toLowerCase() === "true"
+
   const options = {
     listeners: {
       stdout: data => {
@@ -13,7 +15,7 @@ exports.easyExec = async function easyExec (commandWithArgs) {
         error += data.toString()
       }
     },
-    silent: true
+    silent: !debugMode
   }
 
   const commandParts = commandWithArgs.split(' ')


### PR DESCRIPTION
### Background

This action has been installing anything from `package.json` with "prettier" in the name.  That gives us a sort of "plugin support".  

But with the Ruby plugin in particular we need to make a few more changes for this to really work well.  The readme had a recommendation for requiring Ruby (still a thing) and installing running `bundle install`.  For a large project, that can take a while, even with a warm bundler cache.

### Changes

We can be more particular about what we install and this action can do all of that work.  In the interest of separating concerns, I created a simple plugin system that we can use to support more plugins that need to do a bit of extra work. 

There are two big things that this does on the Ruby side:

1. Install the prettier gem if it's in your `Gemfile.lock`.  This is especially necessary for versions >= 3.0 of the plugin that require a few other gems. 
2. Moving the `Gemfile` out of the way before running `prettier --write`.  Because the server side of the prettier Ruby plugin calls `require "bundler/setup"` (again, esp. for 3.x versions of the plugin), moving the `Gemfile` out of the way avoids having bundler complain about missing dependencies that likely aren't necessary for prettier.

