### PR TITLE
change: Remove extensions input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+CHANGE: Remove `extensions` input
+
 ## v0.2 (2022-05-16)
 
 FEAT: Official support for running with prettier/plugin-ruby

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
       - uses: planningcenter/balto-prettier@v0.2
-        with:
-          extensions: js,jsx
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Formatting by balto-prettier
@@ -57,8 +55,6 @@ jobs:
         with:
           bundler: none
       - uses: planningcenter/balto-prettier@v0.2
-        with:
-          extensions: js,jsx,rb,rake
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Formatting by balto-prettier
@@ -67,9 +63,3 @@ jobs:
 ### Other Plugins
 
 If you're using other prettier plugins that rely on other tools or languages, you'll need to set those up, with other actions or steps.
-
-## Inputs
-
-| Name | Description | Required | Default |
-|:-:|:-:|:-:|:-:|
-| `extensions` | A comma separated list of extensions to run Prettier on | no | `"js"` |

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,3 @@ runs:
 branding:
   icon: life-buoy
   color: orange
-inputs:
-  extensions:
-    description: "A comma separated list of extensions to run on"
-    require: false
-    default: "js"

--- a/main.js
+++ b/main.js
@@ -5,10 +5,7 @@ const { easyExec } = require('./utils')
 const availablePlugins = ['./ruby'].map(require)
 const enabledPlugins = []
 
-const {
-  GITHUB_WORKSPACE,
-  INPUT_EXTENSIONS,
-} = process.env
+const { GITHUB_WORKSPACE } = process.env
 
 const event = require(process.env.GITHUB_EVENT_PATH)
 
@@ -72,11 +69,8 @@ async function runPrettier () {
   )
 
   const executable = `${GITHUB_WORKSPACE}/node_modules/.bin/prettier`
-  const extensions = INPUT_EXTENSIONS.split(',')
 
-  const paths = output
-    .split('\n')
-    .filter(path => extensions.some(e => path.endsWith(`.${e}`)))
+  const paths = output.split('\n')
   if (paths.length > 0) {
     await easyExec(`${executable} --write ${paths.join(' ')}`)
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "GITHUB_EVENT_PATH=./test/pull_request_payload.json INPUT_EXTENSIONS=js,jsx,rb,rake node main.js"
+    "test": "GITHUB_EVENT_PATH=./test/pull_request_payload.json node main.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Prettier and its plugins already keep track of what extensions and files they can be run on. In an effort to make sure this runs on everything it can (e.g. `Gemfile`, `.yml`, etc.), we'd do well to let Prettier handle those decisions for us; otherwise we'd be duplicating much of that functionality and knowledge.