### PR TITLE
Add autofix and append-to-file actions

### DIFF
--- a/append-to-file/action.yml
+++ b/append-to-file/action.yml
@@ -1,0 +1,14 @@
+name: "Append to File"
+description: "Append content to a file"
+inputs:
+  filepath:
+    description: "The path to the file to write"
+    required: true
+  contents:
+    description: "The contents to add"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - run: echo "${{ inputs.contents }}" >> ${{ inputs.filepath }}
+      shell: bash

--- a/autofix/action.yml
+++ b/autofix/action.yml
@@ -1,0 +1,27 @@
+name: "Balto Prettier Auto-Fix"
+description: "Run prettier, commit any changes, and add formatting commit to .git-blame-ignore-revs"
+inputs:
+  extensions:
+    description: "A comma separated list of extensions to run on"
+    require: false
+    default: "js"
+runs:
+  using: "composite"
+  steps:
+    - uses: planningcenter/balto-prettier@main
+      with:
+        extensions: ${{ inputs.extensions }}
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      id: balto-prettier-commit
+      with:
+        commit_message: Formatting by balto-prettier
+    - uses: planningcenter/balto-prettier/append-to-file@main
+      if: steps.balto-prettier-commit.outputs.changes_detected == 'true'
+      with:
+        filepath: ${{ github.workspace}}/.git-blame-ignore-revs
+        contents: |-
+          # balto-prettier PR #${{ github.event.number }}
+          ${{ steps.balto-prettier-commit.outputs.commit_hash }}
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Add format commit to .git-blame-ignore-revs


### PR DESCRIPTION
### Background
The base action that's been around for some time does the core work, but it's output isn't much use without other actions around it. 

### Changes
This adds the actions that are used most with it. And being bundled in here means an app can now use `planningcenter/balto-prettier/autofix@{ref}` and get all of the autofix and commit functionality that's most useful.

### Example Usage (aka "testing")
I tried this approach first with [balto-syntax_tree](https://github.com/planningcenter/balto-syntax_tree), and it seems to work quite well ([example PR](https://github.com/ministrycentered/edna/pull/21)).

I've got a [PR into Giving ](https://github.com/ministrycentered/giving/pull/5347)to remove what was essentially this code and use this new action instead.

#### Release:

- [x] Just before merging, update refs in `autofix/action.yml` referencing this repo to `@main`
- [x] Once this lands in `main`, release a new `v1` version
- [x] Update the refs in `autofix/action.yml` to `@v1`.